### PR TITLE
fix bug if <xml>--<manifest> will be break bug

### DIFF
--- a/lib/apkreader.js
+++ b/lib/apkreader.js
@@ -282,9 +282,11 @@ var Apk2XML = {
                  * Unknown parse error
                  */
             } else {
-                apkReader.emit('error', new Error('Unrecognized tag code ' +
-                        tag0.toString(16) + ' at offset ' + off));
-                return;
+                // apkReader.emit('error', new Error('Unrecognized tag code ' +
+                //         tag0.toString(16) + ' at offset ' + off));
+                // return;
+                //because if example is <xml>---<manifast> will be break,so this should off +=2*4
+                off += 2*4;
             }
 
         }

--- a/lib/apkreader.js
+++ b/lib/apkreader.js
@@ -286,7 +286,7 @@ var Apk2XML = {
                 //         tag0.toString(16) + ' at offset ' + off));
                 // return;
                 //because if example is <xml>---<manifast> will be break,so this should off +=2*4
-                off += 2*4;
+                off += 1*4;
             }
 
         }


### PR DESCRIPTION
解决bug 当xml文件不标准时会因为<xml>...<这样不标准文件而退出    test success
